### PR TITLE
[15.0][FIX] aggrement_rebate: The type of movement is defined in the field "move_type"

### DIFF
--- a/agreement_rebate/models/agreement_rebate_settlement.py
+++ b/agreement_rebate/models/agreement_rebate_settlement.py
@@ -88,7 +88,7 @@ class AgreementRebateSettlement(models.Model):
             if values.pop("check_amount", 0.0) < 0.0:
                 for line_vals in values["invoice_line_ids"]:
                     line_vals[2]["price_unit"] *= -1
-                values["type"] = self._reverse_type_map(values["type"])
+                values["move_type"] = self._reverse_type_map(values["move_type"])
         invoices = self.env["account.move"].create(invoice_dic.values())
         return invoices
 


### PR DESCRIPTION
https://github.com/odoo/odoo/blob/5bee606a85eef6b5a1e1802f75a6407482413a30/addons/account/models/account_move.py#L167

cc @Tecnativa TT47494

@pedrobaeza @carlosdauden please review 