### PR TITLE
[15.0][FIX] agreement_rebate: The type of account move is defined in the field move_type

### DIFF
--- a/agreement_rebate/wizards/invoice_create.py
+++ b/agreement_rebate/wizards/invoice_create.py
@@ -96,7 +96,7 @@ class AgreementSettlementInvoiceCreateWiz(models.TransientModel):
         )
         settlements -= settlements.filtered(
             lambda s: any(
-                ail.move_id.type == self.invoice_type
+                ail.move_id.move_type == self.invoice_type
                 for ail in s.line_ids.mapped("invoice_line_ids").filtered(
                     lambda ln: ln.parent_state != "cancel"
                 )


### PR DESCRIPTION
Detected in create_invoices wizard reference to old field 'type', replaced by move_type
