### PR TITLE
[17.0][FIX] Menus are moved and they shouldn't...

### DIFF
--- a/agreement_account/views/agreement.xml
+++ b/agreement_account/views/agreement.xml
@@ -1,10 +1,5 @@
 <odoo>
 
-    <record id="agreement.agreement_menu" model="ir.ui.menu">
-        <field name="parent_id" ref="account.account_management_menu" />
-        <field name="sequence">150</field>
-    </record>
-
     <menuitem
         id="agreement_type_menu"
         action="agreement.agreement_type_action"

--- a/agreement_sale/views/agreement_menu.xml
+++ b/agreement_sale/views/agreement_menu.xml
@@ -1,12 +1,6 @@
 <odoo>
     <menuitem
-        id="agreement.agreement_menu"
-        action="agreement.agreement_action"
-        parent="sale.menu_sale_config"
-        sequence="100"
-    />
-    <menuitem
-        id="agreement.agreement_type_menu"
+        id="agreement_type_menu"
         action="agreement.agreement_type_action"
         parent="sale.menu_sale_config"
         sequence="101"


### PR DESCRIPTION
Without this, the menus are moved to different places according to which was the last installed module. It has no sense IMO.

This was introducted by @alexis-via Your comments would be awesome