### PR TITLE
[15.0][FIX] agreement_rebate: Settlements are excluded if any line has been invoiced before

### DIFF
--- a/agreement_rebate/wizards/invoice_create.py
+++ b/agreement_rebate/wizards/invoice_create.py
@@ -97,9 +97,11 @@ class AgreementSettlementInvoiceCreateWiz(models.TransientModel):
         settlements -= settlements.filtered(
             lambda s: any(
                 ail.move_id.move_type == self.invoice_type
-                for ail in s.line_ids.mapped("invoice_line_ids").filtered(
-                    lambda ln: ln.parent_state != "cancel"
+                for ail in s.line_ids.filtered(
+                    lambda st_line: st_line.invoice_status == "to_invoice"
                 )
+                .mapped("invoice_line_ids")
+                .filtered(lambda ln: ln.parent_state != "cancel")
             )
         )
         invoices = settlements.with_context(


### PR DESCRIPTION
cc @Tecnativa  TT52964

Don't exclude a settlement to be invoiced if has any settlement line with to_invoce status

ping @carlosdauden @CarlosRoca13 