### PR TITLE
[15.0][FIX] agreement_rebate: Settlement lines already invoiced are invoiced twice when process the settlement in tow steps

### DIFF
--- a/agreement_rebate/models/agreement_rebate_settlement.py
+++ b/agreement_rebate/models/agreement_rebate_settlement.py
@@ -68,7 +68,9 @@ class AgreementRebateSettlement(models.Model):
 
     def create_invoice(self):
         invoice_dic = {}
-        for line in self.mapped("line_ids"):
+        for line in self.mapped("line_ids").filtered(
+            lambda ln: ln.invoice_status == "to_invoice"
+        ):
             key = line._get_invoice_key()
             if key not in invoice_dic:
                 invoice_dic[key] = line._prepare_invoice()


### PR DESCRIPTION
cc @Tecnativa TT52964

ping  @carlosdauden @CarlosRoca13 