### PR TITLE
[16.0][FIX] agreement_legal: fix get_view

### DIFF
--- a/agreement_legal/models/agreement.py
+++ b/agreement_legal/models/agreement.py
@@ -466,9 +466,15 @@ class Agreement(models.Model):
         return ["stage_id"]
 
     @api.model
-    def get_view(self, view_id=None, view_type=False, toolbar=False, submenu=False):
+    def get_view(
+        self, view_id=None, view_type=False, toolbar=False, submenu=False, **options
+    ):
         res = super().get_view(
-            view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu
+            view_id=view_id,
+            view_type=view_type,
+            toolbar=toolbar,
+            submenu=submenu,
+            **options
         )
         # Readonly fields
         if view_type == "form":


### PR DESCRIPTION
error: TypeError: Agreement.get_view() got an unexpected keyword argument 'action_id'

Added **options to get_view() in Agreement to handle unexpected action_id argument and ensure compatibility with recent Odoo versions.

@etobella 