### PR TITLE
[16.0][FIX] agreement_legal: Incorrect 'readonly' attribute format

### DIFF
--- a/agreement_legal/models/agreement.py
+++ b/agreement_legal/models/agreement.py
@@ -485,13 +485,11 @@ class Agreement(models.Model):
                 attrs = ast.literal_eval(node.attrib.get("attrs", "{}"))
                 if attrs:
                     if attrs.get("readonly"):
-                        attrs["readonly"] = ["|", ("readonly", "=", True)] + attrs[
-                            "readonly"
-                        ]
+                        attrs["readonly"] = {"readonly: True"} + attrs["readonly"]
                     else:
-                        attrs["readonly"] = [("readonly", "=", True)]
+                        attrs["readonly"] = True
                 else:
-                    attrs["readonly"] = [("readonly", "=", True)]
+                    attrs["readonly"] = True
                 node.set("attrs", simplejson.dumps(attrs))
                 modifiers = ast.literal_eval(
                     node.attrib.get("modifiers", "{}")

--- a/agreement_legal/tests/test_agreement.py
+++ b/agreement_legal/tests/test_agreement.py
@@ -112,9 +112,7 @@ class TestAgreement(TransactionCase):
         )
         doc = etree.XML(res["arch"])
         field = doc.xpath("//field[@name='partner_contact_id']")
-        self.assertEqual(
-            field[0].get("modifiers", ""), '{"readonly": [["readonly", "=", true]]}'
-        )
+        self.assertEqual(field[0].get("modifiers", ""), '{"readonly": true}')
 
     def test_action_create_new_version(self):
         self.test_agreement.create_new_version()


### PR DESCRIPTION
An error related with 'readonly' attribute format is faced while creating clauses on an existing agreement.

```
Error: for modifier "readonly": Unknown field readonly in domain
    at Class._evalModifiers (/web/assets/debug/web.assets_backend.js:96211:23) (/web/static/src/legacy/js/views/basic/basic_model.js:2494)
    at Class._isFieldProtected (/web/assets/debug/web.assets_backend.js:97829:34) (/web/static/src/legacy/js/views/basic/basic_model.js:4112)
    at Class._generateChanges (/web/assets/debug/web.assets_backend.js:97005:26) (/web/static/src/legacy/js/views/basic/basic_model.js:3288)
    at Class._generateX2ManyCommands (/web/assets/debug/web.assets_backend.js:97189:44) (/web/static/src/legacy/js/views/basic/basic_model.js:3472)
    at Class._generateChanges (/web/assets/debug/web.assets_backend.js:96997:29) (/web/static/src/legacy/js/views/basic/basic_model.js:3280)
    at _save (/web/assets/debug/web.assets_backend.js:94871:32) (/web/static/src/legacy/js/views/basic/basic_model.js:1154)
    at https://locahost:8069/web/assets/debug/web.assets_common.js:71637:30 (/web/static/src/legacy/js/core/concurrency.js:195)
```

@mpascuall @peluko00 @BernatObrador  please review