### PR TITLE
[16.0][FIX] agreement_legal: Incorrect 'readonly' attribute format

### DIFF
--- a/agreement_legal/README.rst
+++ b/agreement_legal/README.rst
@@ -101,6 +101,8 @@ Contributors
 * Sandip Mangukiya <smangukiya@opensourceintegrators.com>
 * Yves Goldberg <yves@ygol.com>
 * Tharathip Chaweewongphan <tharathipc@ecosoft.co.th>
+* `APSL-Nagarro <https://apsl.tech>`_:
+    * Antoni Marroig <amarroig@apsl.net>
 
 Other credits
 ~~~~~~~~~~~~~

--- a/agreement_legal/models/agreement.py
+++ b/agreement_legal/models/agreement.py
@@ -466,21 +466,16 @@ class Agreement(models.Model):
         return ["stage_id"]
 
     @api.model
-    def get_view(
-        self, view_id=None, view_type=False, toolbar=False, submenu=False, **options
-    ):
-        res = super().get_view(
-            view_id=view_id,
-            view_type=view_type,
-            toolbar=toolbar,
-            submenu=submenu,
-            **options
-        )
+    def get_view(self, view_id=None, view_type=False, **options):
+        res = super().get_view(view_id=view_id, view_type=view_type, **options)
         # Readonly fields
         if view_type == "form":
             doc = etree.XML(res["arch"])
             for node in doc.xpath("//field"):
-                if node.attrib.get("name") in self._exclude_readonly_field():
+                if (
+                    node in doc.xpath("//tree/field")
+                    or node.attrib.get("name") in self._exclude_readonly_field()
+                ):
                     continue
                 attrs = ast.literal_eval(node.attrib.get("attrs", "{}"))
                 if attrs:

--- a/agreement_legal/readme/CONTRIBUTORS.rst
+++ b/agreement_legal/readme/CONTRIBUTORS.rst
@@ -5,3 +5,5 @@
 * Sandip Mangukiya <smangukiya@opensourceintegrators.com>
 * Yves Goldberg <yves@ygol.com>
 * Tharathip Chaweewongphan <tharathipc@ecosoft.co.th>
+* `APSL-Nagarro <https://apsl.tech>`_:
+    * Antoni Marroig <amarroig@apsl.net>

--- a/agreement_legal/static/description/index.html
+++ b/agreement_legal/static/description/index.html
@@ -450,6 +450,14 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Sandip Mangukiya &lt;<a class="reference external" href="mailto:smangukiya&#64;opensourceintegrators.com">smangukiya&#64;opensourceintegrators.com</a>&gt;</li>
 <li>Yves Goldberg &lt;<a class="reference external" href="mailto:yves&#64;ygol.com">yves&#64;ygol.com</a>&gt;</li>
 <li>Tharathip Chaweewongphan &lt;<a class="reference external" href="mailto:tharathipc&#64;ecosoft.co.th">tharathipc&#64;ecosoft.co.th</a>&gt;</li>
+<li><dl class="first docutils">
+<dt><a class="reference external" href="https://apsl.tech">APSL-Nagarro</a>:</dt>
+<dd><ul class="first last">
+<li>Antoni Marroig &lt;<a class="reference external" href="mailto:amarroig&#64;apsl.net">amarroig&#64;apsl.net</a>&gt;</li>
+</ul>
+</dd>
+</dl>
+</li>
 </ul>
 </div>
 <div class="section" id="other-credits">


### PR DESCRIPTION
An error related with 'readonly' attribute format is faced while creating clauses on an existing agreement.
```
Error: for modifier "readonly": Unknown field readonly in domain
    at Class._evalModifiers (/web/assets/debug/web.assets_backend.js:96211:23) (/web/static/src/legacy/js/views/basic/basic_model.js:2494)
    at Class._isFieldProtected (/web/assets/debug/web.assets_backend.js:97829:34) (/web/static/src/legacy/js/views/basic/basic_model.js:4112)
    at Class._generateChanges (/web/assets/debug/web.assets_backend.js:97005:26) (/web/static/src/legacy/js/views/basic/basic_model.js:3288)
    at Class._generateX2ManyCommands (/web/assets/debug/web.assets_backend.js:97189:44) (/web/static/src/legacy/js/views/basic/basic_model.js:3472)
    at Class._generateChanges (/web/assets/debug/web.assets_backend.js:96997:29) (/web/static/src/legacy/js/views/basic/basic_model.js:3280)
    at _save (/web/assets/debug/web.assets_backend.js:94871:32) (/web/static/src/legacy/js/views/basic/basic_model.js:1154)
    at https://locahost:8069/web/assets/debug/web.assets_common.js:71637:30 (/web/static/src/legacy/js/core/concurrency.js:195)
``` 

cc https://github.com/APSL 6526
@miquelalzanillas @lbarry-apsl @javierobcn @mpascuall @BernatObrador @ppyczko please review