### PR TITLE
[18.0][IMP] agreement_rebate: neaten up rebate settlement view

### DIFF
--- a/agreement_rebate/views/agreement_rebate_settlement_view.xml
+++ b/agreement_rebate/views/agreement_rebate_settlement_view.xml
@@ -99,24 +99,20 @@
                         <group>
                             <field name="name" />
                             <field name="partner_id" />
+                            <field name="amount_invoiced" />
+                            <field name="amount_rebate" />
                         </group>
                         <group>
                             <field name="date" />
+                            <field name="date_from" />
+                            <field name="date_to" />
                             <field name="active" invisible="1" />
                         </group>
-                    </group>
-                    <group>
-                        <field name="date_from" />
-                        <field name="date_to" />
-                    </group>
-                    <group>
-                        <field name="amount_invoiced" />
-                        <field name="amount_rebate" />
                     </group>
                     <group string="Lines">
                         <field name="line_ids" nolabel="1" colspan="2">
                             <list>
-                                <field name="rebate_type" invisible="1" />
+                                <field name="rebate_type" column_invisible="1" />
                                 <field name="partner_id" readonly="1" />
                                 <field name="amount_invoiced" />
                                 <field name="percent" />


### PR DESCRIPTION
From
<img width="1104" height="258" alt="image" src="https://github.com/user-attachments/assets/97e61f50-cadd-4440-baf9-975aa409cc3d" />


To (except one custom field)
<img width="1498" height="169" alt="image" src="https://github.com/user-attachments/assets/ccede833-2070-49a7-845f-ae9a54b671e4" />

resolves #80 
