### PR TITLE
[16.0][FIX] agreement_legal_ fix security issue

### DIFF
--- a/agreement_legal/models/res_partner.py
+++ b/agreement_legal/models/res_partner.py
@@ -22,8 +22,9 @@ class Partner(models.Model):
 
     def action_open_agreement(self):
         self.ensure_one()
-        action = self.env.ref("agreement.agreement_action")
-        result = action.read()[0]
-        result["domain"] = [("partner_id", "=", self.id)]
-        result["context"] = {"default_partner_id": self.id}
-        return result
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "agreement.agreement_action"
+        )
+        action["domain"] = [("partner_id", "=", self.id)]
+        action["context"] = {"default_partner_id": self.id}
+        return action


### PR DESCRIPTION
When I try to access the Agreements button_box from the Vendors form, I get a permissions error. I traced it and found that the action_open_agreement function reads an ir.actions.act_window without sudo. I think the cleaner, simpler approach is to return the action dictionary directly, which avoids the permissions error.

<img width="663" height="349" alt="image" src="https://github.com/user-attachments/assets/426c1f1b-efa0-447f-bd66-cec560c36a94" />

@etobella 