### PR TITLE
[18.0][IMP] agreement_sale: fix when upgrade agreement_sale menu Agreements is disappear

### DIFF
--- a/agreement_sale/views/agreement_menu.xml
+++ b/agreement_sale/views/agreement_menu.xml
@@ -1,15 +1,16 @@
 <odoo>
+    <!-- Agreement Type -->
     <menuitem
-        id="agreement.agreement_menu"
-        action="agreement.agreement_action"
-        parent="sale.menu_sale_config"
-        sequence="100"
+        name="Agreement Type"
+        id="agreement.agreement_type_menu_main"
+        parent="agreement.agreement_menu"
+        sequence="45"
     />
     <menuitem
         id="agreement.agreement_type_menu"
         action="agreement.agreement_type_action"
-        parent="sale.menu_sale_config"
-        sequence="101"
+        parent="agreement.agreement_type_menu_main"
+        sequence="10"
         groups="agreement.group_use_agreement_type"
     />
 </odoo>


### PR DESCRIPTION
Problem:
install module agreement_legal, menu Agreements show on sidemenu
<img width="1853" height="960" alt="Selection_024" src="https://github.com/user-attachments/assets/f86ffdcc-be13-433c-9042-28da93959146" />

but when install module agreement_sale menu Agreements on sidemenu will disappear and it's show on menu sale > configuration > Agreements
<img width="1848" height="958" alt="Selection_025" src="https://github.com/user-attachments/assets/67ccfe85-8e4a-48a0-b340-68aa78654b29" />
<img width="1853" height="960" alt="Selection_026" src="https://github.com/user-attachments/assets/e5495942-d26f-4db9-a8ef-5aa94a763e13" />
<img width="1850" height="960" alt="Selection_027" src="https://github.com/user-attachments/assets/5c730e9f-5bb7-4975-8e97-7edf730d2925" />

Sol:
- remove top menu in agreement_sale and can create only sub-menu
- parent of sub-menu will point at top menu of agreement_legal (agreement.agreement_menu)