### PR TITLE
[18.0][FIX] agreement_legal: use url instead kanban_image()

### DIFF
--- a/agreement_legal/views/agreement.xml
+++ b/agreement_legal/views/agreement.xml
@@ -485,12 +485,9 @@
                                         t-if="record.assigned_user_id.raw_value"
                                     >
                                         <img
-                                            t-att-src="kanban_image('res.users', 'image_128', record.assigned_user_id.raw_value)"
-                                            t-att-title="record.assigned_user_id.value"
-                                            width="36"
-                                            height="36"
-                                            class="oe_kanban_avatar"
+                                            t-att-src="'/web/image/res.users/' + record.assigned_user_id.raw_value + '/avatar_128'"
                                             alt="user &amp; picture"
+                                            class="o_image_24_cover float-start mb-2 me-2"
                                         />
                                     </div>
                                 </div>


### PR DESCRIPTION
Error when add `Assigned To` on agreement because `kanban_image()` is not used in odoo18

Step to test:
1. Install module `agreement_legal`
2. After that, you can't click on menu agreement
<img width="1713" height="943" alt="selection_004" src="https://github.com/user-attachments/assets/36964447-dea1-4e3a-acb9-f58d60c957b8" />


After Fixed:
<img width="1098" height="543" alt="selection_005" src="https://github.com/user-attachments/assets/18d510c9-8c77-4bbc-8cd6-2cac29133986" />
