### PR TITLE
[18.0][FIX] agreement_legal: remove redundant t-name from report_agreement_document

### DIFF
--- a/agreement_legal/report/agreement.xml
+++ b/agreement_legal/report/agreement.xml
@@ -20,160 +20,149 @@
     </record>
 
     <template id="report_agreement_document">
-        <t t-name="agreement.report_agreement_document">
-            <t t-call="web.html_container">
-                <t t-foreach="docs" t-as="doc">
-                    <t t-call="web.external_layout">
-                        <div class="page">
-                            <h1 t-field="doc.name" />
-                            <div name="description">
-                                <span t-field="doc.dynamic_description" />
-                            </div>
-                            <h2>Parties</h2>
-                            <div name="parties">
-                                <t t-if="doc.use_parties_content">
-                                    <p t-field="doc.dynamic_parties" />
-                                </t>
-                            </div>
-                            <t t-if="not doc.use_parties_content">
-                                <h3>Company Information</h3>
-                                <div name="company_address">
-                                    <address
-                                        t-field="doc.company_id.partner_id"
-                                        t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'
-                                    />
-                                </div>
-                                <div name="company_contact">
-                                    Represented by <span
-                                    t-field="doc.company_contact_id.name"
-                                />.
-                                </div>
-                                <h3>Partner Information</h3>
-                                <div name="partner_address">
-                                    <address
-                                        t-field="doc.partner_id"
-                                        t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'
-                                    />
-                                </div>
-                                <div name="partner_contact">
-                                    Represented by <span
-                                    t-field="doc.partner_contact_id.name"
-                                />.
-                                </div>
-                            </t>
-                            <h2>Agreement</h2>
-                            <h3>Recitals</h3>
-                            <table class="table table-condensed">
-                                <tbody>
-                                    <tr>
-                                        <td>
-                                            <ol>
-                                                <li
-                                                    t-foreach="doc.recital_ids"
-                                                    t-as="r"
-                                                >
-                                                    <t t-if="r.title">
-                                                        <h3 t-field="r.title" />
-                                                    </t>
-                                                    <p t-field="r.dynamic_content" />
-                                                </li>
-                                            </ol>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                            <table class="table table-condensed">
-                                <tbody class="section_tbody">
-                                    <tr>
-                                        <td>
-                                            <ol>
-                                                <li
-                                                    t-foreach="doc.sections_ids"
-                                                    t-as="s"
-                                                >
-                                                    <t t-if="s.title">
-                                                        <h3 t-field="s.title" />
-                                                    </t>
-                                                    <p t-field="s.dynamic_content" />
-                                                    <ol>
-                                                        <li
-                                                            t-foreach="s.clauses_ids"
-                                                            t-as="c"
-                                                        >
-                                                            <t t-if="c.title">
-                                                                <h4 t-field="c.title" />
-                                                            </t>
-                                                            <p
-                                                                t-field="c.dynamic_content"
-                                                            />
-                                                        </li>
-                                                    </ol>
-                                                </li>
-                                            </ol>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                            <t t-if="special_term">
-                                <h2>Special Terms</h2>
-                                <div name="special_term">
-                                    <p t-field="doc.dynamic_special_terms" />
-                                </div>
-                            </t>
-                            <h2>Signatures</h2>
-                            <table class="table table-condensed">
-                                <theader>
-                                    <tr>
-                                        <th>Partner</th>
-                                        <th>Company</th>
-                                    </tr>
-                                </theader>
-                                <tbody class="section_tbody">
-                                    <tr>
-                                        <td>
-                                            <p t-field="doc.partner_id" />
-                                            <p>By: </p>
-                                            <p>
-                                                Name: <span
-                                                t-field="doc.partner_contact_id.name"
-                                            />
-                                            </p>
-                                            <p>
-                                                Title: <span
-                                                t-field="doc.partner_contact_id.function"
-                                            />
-                                            </p>
-                                            <p>Date: </p>
-                                        </td>
-                                        <td>
-                                            <p t-field="doc.company_id.partner_id" />
-                                            <p>By: </p>
-                                            <p>
-                                                Name: <span
-                                                t-field="doc.company_contact_id.name"
-                                            />
-                                            </p>
-                                            <p>
-                                                Title: <span
-                                                t-field="doc.company_contact_id.function"
-                                            />
-                                            </p>
-                                            <p>Date: </p>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="doc">
+                <t t-call="web.external_layout">
+                    <div class="page">
+                        <h1 t-field="doc.name" />
+                        <div name="description">
+                            <span t-field="doc.dynamic_description" />
                         </div>
-                        <div t-foreach="doc.appendix_ids" t-as="a">
-                            <div class="page">
-                                <h1
-                                    t-field="a.title"
-                                    style="page-break-before: always;"
+                        <h2>Parties</h2>
+                        <div name="parties">
+                            <t t-if="doc.use_parties_content">
+                                <p t-field="doc.dynamic_parties" />
+                            </t>
+                        </div>
+                        <t t-if="not doc.use_parties_content">
+                            <h3>Company Information</h3>
+                            <div name="company_address">
+                                <address
+                                    t-field="doc.company_id.partner_id"
+                                    t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'
                                 />
-                                <p t-field="a.dynamic_content" />
                             </div>
+                            <div name="company_contact">
+                                Represented by <span
+                                t-field="doc.company_contact_id.name"
+                            />.
+                            </div>
+                            <h3>Partner Information</h3>
+                            <div name="partner_address">
+                                <address
+                                    t-field="doc.partner_id"
+                                    t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'
+                                />
+                            </div>
+                            <div name="partner_contact">
+                                Represented by <span
+                                t-field="doc.partner_contact_id.name"
+                            />.
+                            </div>
+                        </t>
+                        <h2>Agreement</h2>
+                        <h3>Recitals</h3>
+                        <table class="table table-condensed">
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <ol>
+                                            <li t-foreach="doc.recital_ids" t-as="r">
+                                                <t t-if="r.title">
+                                                    <h3 t-field="r.title" />
+                                                </t>
+                                                <p t-field="r.dynamic_content" />
+                                            </li>
+                                        </ol>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table class="table table-condensed">
+                            <tbody class="section_tbody">
+                                <tr>
+                                    <td>
+                                        <ol>
+                                            <li t-foreach="doc.sections_ids" t-as="s">
+                                                <t t-if="s.title">
+                                                    <h3 t-field="s.title" />
+                                                </t>
+                                                <p t-field="s.dynamic_content" />
+                                                <ol>
+                                                    <li
+                                                        t-foreach="s.clauses_ids"
+                                                        t-as="c"
+                                                    >
+                                                        <t t-if="c.title">
+                                                            <h4 t-field="c.title" />
+                                                        </t>
+                                                        <p
+                                                            t-field="c.dynamic_content"
+                                                        />
+                                                    </li>
+                                                </ol>
+                                            </li>
+                                        </ol>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <t t-if="special_term">
+                            <h2>Special Terms</h2>
+                            <div name="special_term">
+                                <p t-field="doc.dynamic_special_terms" />
+                            </div>
+                        </t>
+                        <h2>Signatures</h2>
+                        <table class="table table-condensed">
+                            <theader>
+                                <tr>
+                                    <th>Partner</th>
+                                    <th>Company</th>
+                                </tr>
+                            </theader>
+                            <tbody class="section_tbody">
+                                <tr>
+                                    <td>
+                                        <p t-field="doc.partner_id" />
+                                        <p>By: </p>
+                                        <p>
+                                            Name: <span
+                                            t-field="doc.partner_contact_id.name"
+                                        />
+                                        </p>
+                                        <p>
+                                            Title: <span
+                                            t-field="doc.partner_contact_id.function"
+                                        />
+                                        </p>
+                                        <p>Date: </p>
+                                    </td>
+                                    <td>
+                                        <p t-field="doc.company_id.partner_id" />
+                                        <p>By: </p>
+                                        <p>
+                                            Name: <span
+                                            t-field="doc.company_contact_id.name"
+                                        />
+                                        </p>
+                                        <p>
+                                            Title: <span
+                                            t-field="doc.company_contact_id.function"
+                                        />
+                                        </p>
+                                        <p>Date: </p>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div t-foreach="doc.appendix_ids" t-as="a">
+                        <div class="page">
+                            <h1 t-field="a.title" style="page-break-before: always;" />
+                            <p t-field="a.dynamic_content" />
                         </div>
-                    </t>
+                    </div>
                 </t>
             </t>
         </t>


### PR DESCRIPTION
**Issue:**
The `report_agreement_document` template contained a redundant `<t t-name="agreement.report_agreement_document">` wrapper inside the `<template>` tag. In modern Odoo versions, this triggers the following warning in the logs:
`Unknown directives or unused attributes: {'t-name'} in agreement_legal.report_agreement_document`

Reference :- https://github.com/OCA/sign/pull/118