### PR TITLE
[19.0][FIX] agreement_rebate: always return a Domain from _target_line_domain

### DIFF
--- a/agreement_rebate/wizards/settlement_create.py
+++ b/agreement_rebate/wizards/settlement_create.py
@@ -116,30 +116,21 @@ class AgreementSettlementCreateWiz(models.TransientModel):
         return domain
 
     def _target_line_domain(self, agreement_domain, agreement, line=False):
-        domain = agreement_domain.copy()
+        domain = Domain(agreement_domain)
         if agreement.start_date:
-            domain.append(
-                (
-                    "invoice_date",
-                    ">=",
-                    fields.Date.to_string(agreement.start_date),
-                )
+            domain &= Domain(
+                "invoice_date", ">=", fields.Date.to_string(agreement.start_date)
             )
         if agreement.end_date:
-            domain.append(
-                (
-                    "invoice_date",
-                    "<=",
-                    fields.Date.to_string(agreement.end_date),
-                )
+            domain &= Domain(
+                "invoice_date", "<=", fields.Date.to_string(agreement.end_date)
             )
         if line:
-            domain += safe_eval(line.rebate_domain)
+            domain &= Domain(safe_eval(line.rebate_domain))
         elif agreement.rebate_line_ids:
-            line_domains = Domain.OR(
+            domain &= Domain.OR(
                 [Domain(safe_eval(x.rebate_domain)) for x in agreement.rebate_line_ids]
             )
-            domain = Domain(domain) & line_domains
         return domain
 
     def get_agregate_fields(self):


### PR DESCRIPTION
## Description

In 19.0, `AgreementSettlementCreateWiz._target_line_domain` returns
inconsistent types depending on the agreement:

- a plain `list` in the common case, but
- a `Domain` object when the agreement has `rebate_line_ids` (via
  `Domain(domain) & line_domains`).

Any caller — or module overriding this method — that treats the result
as a list then breaks against a `Domain`. In a downstream module this
surfaced as:

```
AttributeError: 'DomainAnd' object has no attribute 'append'
```

## What this PR does

Composes the domain natively using `Domain` and the `&` operator so the
method **always** returns a `Domain`, which is the 19.0 idiom.

## Backward compatibility

Behaviour is unchanged:

- The extra leaves (`invoice_date` bounds, per-line/`rebate_line_ids`
  domains) are still AND-ed together, matching the previous implicit
  top-level AND of list concatenation.
- Internal consumers already accept a `Domain`: `_read_group` takes a
  `Domain`, and the `target_domain` `Char` field round-trips it through
  its list-style `repr` (already the case today for the `rebate_line_ids`
  branch).
- `Domain` remains iterable to the old-style list, so any external code
  still doing `list(...)` keeps working.

Made with [Cursor](https://cursor.com)