### PR TITLE
[18.0][FIX] agreement: open partner agreements as a non-admin user

### DIFF
--- a/agreement/models/res_partner.py
+++ b/agreement/models/res_partner.py
@@ -22,8 +22,9 @@ class Partner(models.Model):
 
     def action_open_agreement(self):
         self.ensure_one()
-        action = self.env.ref("agreement.agreement_action")
-        result = action.read()[0]
+        result = self.env["ir.actions.act_window"]._for_xml_id(
+            "agreement.agreement_action"
+        )
         result["domain"] = [("partner_id", "=", self.id)]
         result["context"] = {"default_partner_id": self.id}
         return result

--- a/agreement/tests/test_agreement.py
+++ b/agreement/tests/test_agreement.py
@@ -2,6 +2,7 @@
 # Copyright 2021 Sergio Teruel - Tecnativa
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
+from odoo import Command
 from odoo.tests.common import TransactionCase
 
 
@@ -30,6 +31,20 @@ class TestAgreement(TransactionCase):
     def test_compute_display_name(self):
         display_name = self.agreement.display_name
         self.assertEqual(display_name, f"[{self.agreement.code}] {self.agreement.name}")
+
+    def test_partner_action_open_agreement(self):
+        user = self.env["res.users"].create(
+            {
+                "name": "Test Agreement User",
+                "login": "test_agreement_user",
+                "groups_id": [Command.set([self.env.ref("base.group_user").id])],
+            }
+        )
+        partner = self.agreement.partner_id
+        action = partner.with_user(user).action_open_agreement()
+        self.assertEqual(action["res_model"], "agreement")
+        self.assertEqual(action["domain"], [("partner_id", "=", partner.id)])
+        self.assertEqual(action["context"]["default_partner_id"], partner.id)
 
     def test_copy(self):
         agreement1 = self.agreement.copy(default={"code": "Test Code"})


### PR DESCRIPTION
**Steps to error**

1. Install `agreement` with demo data.
2. Log in as an Internal User who is not in `Administration/Settings`, e.g. `demo`.
<img width="1247" height="355" alt="SCR-20260827-txvt" src="https://github.com/user-attachments/assets/bbb05e57-feaa-4ad3-952c-28038144836f" />

3. Open the Contact form for `base.res_partner_12`, which has an Agreement.
4. Click the **Agreements** stat button.
<img width="1178" height="429" alt="SCR-20260827-udnh" src="https://github.com/user-attachments/assets/abfa8e0f-20bc-4fd4-8916-f1f119174602" />

5. An Access Error is raised.
<img width="1182" height="388" alt="SCR-20260827-udab" src="https://github.com/user-attachments/assets/59a2d123-e69f-4f4f-bfec-a00ab0efa64d" />




**Root cause**

The existing code uses `action.read()[0]`, which reads the Action with the current user's permissions. However, the core ACL for this model only allows `group_system`, causing an Access Error for regular users.

**Fix**

Use `_for_xml_id()` instead, which handles reading the Action with `sudo` and returns only the fields required by the web client. This is preferred over `sudo().read()[0]` to avoid granting or reading more data than necessary.
