### PR TITLE
[FIX] agreement_legal: copy agreement not get the current agreement I…

### DIFF
--- a/agreement_legal/models/agreement.py
+++ b/agreement_legal/models/agreement.py
@@ -295,7 +295,10 @@ class Agreement(models.Model):
                 section_map[section.id] = new_section.id
 
             for clause in template.clauses_ids:
-                values = {"agreement_id": agreement.id}
+                values = {
+                    "agreement_id": agreement.id,
+                    "temp_agreement_id": agreement.id,
+                }
                 if clause.section_id:
                     values["section_id"] = section_map.get(clause.section_id.id)
                 clause.copy(values)
@@ -486,7 +489,10 @@ class Agreement(models.Model):
             )
             section_map[section.id] = new_section.id
         for clause in self.clauses_ids:
-            values = {"agreement_id": res.id}
+            values = {
+                "agreement_id": res.id,
+                "temp_agreement_id": res.id,
+            }
             if clause.section_id:
                 values["section_id"] = section_map.get(clause.section_id.id)
             clause.copy(values)

--- a/agreement_legal/tests/test_agreement.py
+++ b/agreement_legal/tests/test_agreement.py
@@ -245,6 +245,65 @@ class TestAgreement(TransactionCase):
             child_template.id,
         )
 
+    def test_copy_sets_temp_agreement_id_on_clauses(self):
+        section = self.env["agreement.section"].create(
+            {
+                "name": "Section for Copy",
+                "agreement_id": self.test_agreement.id,
+            }
+        )
+        self.env["agreement.clause"].create(
+            {
+                "name": "Clause with temp agreement",
+                "agreement_id": self.test_agreement.id,
+                "section_id": section.id,
+            }
+        )
+
+        copied_agreement = self.test_agreement.copy()
+
+        self.assertTrue(copied_agreement.clauses_ids)
+        self.assertTrue(
+            all(
+                clause.temp_agreement_id.id == copied_agreement.id
+                for clause in copied_agreement.clauses_ids
+            )
+        )
+
+    def test_recompute_sets_temp_agreement_id_on_clauses(self):
+        template = self.env["agreement"].create(
+            {
+                "name": "Template for Temp Agreement",
+                "is_template": True,
+            }
+        )
+        template_section = self.env["agreement.section"].create(
+            {
+                "name": "Template Section",
+                "agreement_id": template.id,
+            }
+        )
+        self.env["agreement.clause"].create(
+            {
+                "name": "Template Clause",
+                "agreement_id": template.id,
+                "section_id": template_section.id,
+            }
+        )
+
+        self.test_agreement.template_id = template.id
+        self.test_agreement.with_context(
+            active_ids=self.test_agreement.ids,
+        ).recompute_from_template()
+
+        self.assertTrue(self.test_agreement.clauses_ids)
+        self.assertTrue(
+            all(
+                clause.temp_agreement_id.id == self.test_agreement.id
+                for clause in self.test_agreement.clauses_ids
+            )
+        )
+
     def test_action_open_recompute_from_template_wizard(self):
         template = self.env["agreement"].create(
             {


### PR DESCRIPTION
When an agreement is copied from the template, the temp_agreement_id does not pick up the ID of the new agreement, which makes it impossible to select the section of the created agreement.

cc https://github.com/APSL

@shirashi3771 @palomagrc93 @miquelalzanillas @peluko00 @BernatObrador @cubells @miquelpascual @ppyczko @isugac @javierobcn please review.