### PR TITLE
[19.0][ADD] agreement: add user_id field to Agreement model and views

### DIFF
--- a/agreement/models/agreement.py
+++ b/agreement/models/agreement.py
@@ -36,6 +36,13 @@ class Agreement(models.Model):
         string="Company",
         default=lambda self: self.env.company,
     )
+    user_id = fields.Many2one(
+        "res.users",
+        string="Responsible",
+        default=lambda self: self.env.user,
+        tracking=True,
+        help="User in charge of this agreement.",
+    )
     is_template = fields.Boolean(
         string="Is a Template?",
         copy=False,

--- a/agreement/tests/test_agreement.py
+++ b/agreement/tests/test_agreement.py
@@ -32,6 +32,12 @@ class TestAgreement(TransactionCase):
         self.agreement.write({"agreement_type_id": self.agreement_type.id})
         self.assertEqual(self.agreement.domain, self.agreement_type.domain)
 
+    def test_user_id_defaults_to_current_user(self):
+        self.assertEqual(self.agreement.user_id, self.env.user)
+        other = self.env["res.users"].create({"name": "Other", "login": "other_user"})
+        self.agreement.user_id = other
+        self.assertEqual(self.agreement.user_id, other)
+
     def test_compute_display_name(self):
         display_name = self.agreement.display_name
         self.assertEqual(display_name, f"[{self.agreement.code}] {self.agreement.name}")

--- a/agreement/views/agreement.xml
+++ b/agreement/views/agreement.xml
@@ -32,6 +32,7 @@
                         <group name="left">
                             <field name="code" />
                             <field name="partner_id" required="not is_template" />
+                            <field name="user_id" widget="many2one_avatar_user" />
                             <field
                                 name="agreement_type_id"
                                 groups="agreement.group_use_agreement_type"
@@ -68,6 +69,7 @@
                 <field name="partner_id" />
                 <field name="code" />
                 <field name="name" />
+                <field name="user_id" widget="many2one_avatar_user" />
                 <field name="signature_date" />
                 <field name="start_date" />
                 <field name="end_date" />
@@ -87,6 +89,12 @@
                     string="Name or Number"
                 />
                 <field name="partner_id" />
+                <field name="user_id" />
+                <filter
+                    name="my_agreements"
+                    string="My Agreements"
+                    domain="[('user_id', '=', uid)]"
+                />
                 <separator />
                 <filter name="sale" string="Sale" domain="[('domain', '=', 'sale')]" />
                 <filter
@@ -101,6 +109,11 @@
                     domain="[('active', '=', False)]"
                 />
                 <group name="groupby">
+                    <filter
+                        name="user_groupby"
+                        string="Responsible"
+                        context="{'group_by': 'user_id'}"
+                    />
                     <filter
                         name="partner_groupby"
                         string="Partner"


### PR DESCRIPTION
Add a responsible person to agreement like sales person on contact. This makes it easier to select the correct user for reminder activities.